### PR TITLE
양혜림 / 3주차

### DIFF
--- a/hyelim/code_77484.cpp
+++ b/hyelim/code_77484.cpp
@@ -1,0 +1,33 @@
+﻿// 프로그래머스 - 로또의 최고 순위외 최저 순위 (77484)
+
+
+#include <string>
+#include <vector>
+#include <unordered_set>
+
+using namespace std;
+
+vector<int> solution(vector<int> lottos, vector<int> win_nums) {
+    int rank[7] = { 6, 6, 5, 4, 3, 2, 1 };  // 당첨 개수에 따른 순위
+    int zero = 0, same = 0;  // 0의 개수, 같은 번호 개수
+
+    unordered_set<int> win_sets(win_nums.begin(), win_nums.end());
+    // 중복 허용X, 정렬되지 않은 해시 기반 자료구조 생성, 이 안에 당첨 번호를 넣음
+    
+    // 아래와 같음
+    /*
+    for (int num : win_nums) {
+    win_set.insert(num);
+    }
+    */
+
+    for (int i : lottos)
+    {
+        if (i == 0)  // 0 개수 찾기
+            zero++;
+        else if (win_sets.count(i))  // 같은 번호 개수 찾기
+            same++;
+    }
+
+    return { rank[same + zero], rank[same] };
+}


### PR DESCRIPTION
**< 프로그래머스 77484 >**

로또의 최고 순위와 최저 순위를 정하는 문제이다.
즉, 어차피 최고/최저 순위만 구하면 되는 것이므로 0의 개수와 맞춘 번호의 개수만 알면 된다.

그래서 구매한 로또 번호와 추첨 번호를 비교하여 당첨된 개수를 구하는 것이니
각각 배열에 넣고 숫자를 비교해서 맞춘 번호를 세면 된다고 생각했다.

**sol 1 ) 2중 for문 사용**
제일 처음에 떠오른 생각은 2중 for문을 사용하여 배열을 반복해서 찾으려고 했다. 근데 생각해보니 비효율적임 

**sol 2 ) 해시 방식 사용**
현재 코드의 방식이다.
해시를 사용했을 때 상대적으로 시간 복잡도가 줄어들며 숫자를 탐색할 때 count()를 사용할 수 있다.

내가 사용한 unordered_set()은 중복을 허용하지 않고 정렬되지 않은 해시 기반의 자료구조이므로
0이 들어갈 수도 있는 구매한 로또 번호는 만들지 않고, 조건에 모두 해당되는 추첨 번호만 해시 형태로 생성했다.

이후 내가 입력 받은 숫자가 0인지 아닌지에 따라 if문을 통해 1차로 걸러낸 후,
0이 아닌 숫자가 왔을 때 그 숫자가 당첨 번호에 있는지 count()를 사용하여 찾았다.
당첨 번호에 포함되어 있다면 1을 반환하므로 if문이 true → same을 ++ 해준다.

최종적으로 모든 숫자를 비교한 후에는 0의 개수, 맞춘 번호의 개수를 구할 수 있다.
여기서 구해야 하는 것은 최고 순위와 최저 순위이므로 내가 어떤 숫자를 맞췄는지는 알 필요가 없다.
따라서 0으로 지정한 번호를 다 맞췄다고 가정했을 때가 최고 순위일 것이고,
0으로 지정한 번호를 다 틀렸다고 가정했을 때가 최저 순위일 것이다. 

즉, 최고 순위는 현재 맞춘 번호 + 0의 개수, 최저 순위는 현재 맞춘 번호로만 등수를 구하면 되므로
`return { rank[same + zero], rank[same] };`
위의 코드와 같이 반환하면 된다.

**/**

📝

- unordered_set: 중복을 허용하지 않고, 정렬되지 않은 해시 기반의 집합 자료구조
장점 : 탐색 속도가 빠르고(평균 O(1)) 요소의 존재 여부를 빠르게 확인할 수 있음

- count() : 해당 요소가 집합에 존재하는 경우 1, 아니면 0을 반환
